### PR TITLE
Remove forced locale when sign in

### DIFF
--- a/projects/auth-cas-mod/src/lib/auth-cas-mod.service.ts
+++ b/projects/auth-cas-mod/src/lib/auth-cas-mod.service.ts
@@ -85,7 +85,7 @@ export class AuthCasModService {
   }
 
   getUrlLogin(): string {
-    return this.environment.cas_url + '/login?locale=pt_BR&service=' + this.environment.app_url
+    return this.environment.cas_url + '/login?service=' + this.environment.app_url
   }
 
   isAuthenticated(): boolean {


### PR DESCRIPTION
Leave the CAS system determine the language to use instead of forcing it.